### PR TITLE
Undeploy an Index from a IndexEndpoint

### DIFF
--- a/undeploy-index.sh
+++ b/undeploy-index.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+gcloud ai index-endpoints undeploy-index \
+  $INDEX_ENDPOINT \
+  --deployed-index-id="my_demo_index_22" \
+  --region=us-central1


### PR DESCRIPTION
https://github.com/daiiz/vertexai-matching-engine-demo/pull/3#issuecomment-1579915972 で調べたコマンドを使う

```sh
$ INDEX_ENDPOINT="projects/349.../locations/us-central1/indexEndpoints/689..." sh undeploy-index.sh
```

リソース名 `NDEX_ENDPOINT` は findnames.sh で調べられる。

実行中...

![](https://gyazo.com/b3ae8c2696512084581fff6b5e60b06a/thumb/540)


完了

![](https://gyazo.com/f60c1b754049148f1ad987774fdb0708/thumb/540)